### PR TITLE
fix: replace \n with <br> for shell-safe multiline delimiter

### DIFF
--- a/cmd/unid/guide.go
+++ b/cmd/unid/guide.go
@@ -59,7 +59,7 @@ CONTENT & LEGEND:
   content(c)=         Text inside the object (box inner area, text object)
   legend(lg)=         Text outside/near the object (box, hline, vline, arrow)
   content(c)= and legend(lg)= must be the last options on a line.
-  Use \n for multiline text. Leading/trailing whitespace per line is trimmed.
+  Use <br> for multiline text. Leading/trailing whitespace per line is trimmed.
 
 OVERFLOW MODES (overflow(o)= / legend-overflow(lo)= / global "overflow"):
   ellipsis(el, default): Truncate with "prefix..{N}" where N=truncated display width

--- a/internal/dsl/dsl_test.go
+++ b/internal/dsl/dsl_test.go
@@ -133,7 +133,7 @@ func TestParseErrorInvalidID(t *testing.T) {
 }
 
 func TestParseContentNewline(t *testing.T) {
-	cmds, err := Parse(`text 0 0 c=line1\nline2`)
+	cmds, err := Parse(`text 0 0 c=line1<br>line2`)
 	require.NoError(t, err)
 	obj := cmds[0].(*ObjectCmd).Object.(*object.Text)
 	assert.Equal(t, "line1\nline2", obj.Content)

--- a/internal/dsl/parser.go
+++ b/internal/dsl/parser.go
@@ -555,7 +555,7 @@ func extractContent(tokens []string, from, line int) (string, error) {
 				return "", &uerr.ParseError{Line: line, Message: "content= requires a value"}
 			}
 			content := strings.Join(parts, " ")
-			content = strings.ReplaceAll(content, `\n`, "\n")
+			content = strings.ReplaceAll(content, "<br>", "\n")
 			// Trim each line
 			lines := strings.Split(content, "\n")
 			for j := range lines {
@@ -593,7 +593,7 @@ func extractLegend(tokens []string, from, line int) (string, error) {
 				return "", &uerr.ParseError{Line: line, Message: "lg= requires a value"}
 			}
 			content := strings.Join(parts, " ")
-			content = strings.ReplaceAll(content, `\n`, "\n")
+			content = strings.ReplaceAll(content, "<br>", "\n")
 			lines := strings.Split(content, "\n")
 			for j := range lines {
 				lines[j] = strings.TrimSpace(lines[j])

--- a/tests/fixtures/content_with_newline_escape.dsl
+++ b/tests/fixtures/content_with_newline_escape.dsl
@@ -1,2 +1,2 @@
 collision off
-box 0 0 10 3 c=Line1\nLine2
+box 0 0 10 3 c=Line1<br>Line2

--- a/tests/fixtures/multiline_rect_vertical_center.dsl
+++ b/tests/fixtures/multiline_rect_vertical_center.dsl
@@ -1,2 +1,2 @@
 collision off
-box 0 0 8 3 align=c c=AA\nBB
+box 0 0 8 3 align=c c=AA<br>BB

--- a/tests/fixtures/multiline_text_object.dsl
+++ b/tests/fixtures/multiline_text_object.dsl
@@ -1,2 +1,2 @@
 collision off
-text 0 0 c=Hello\nWorld
+text 0 0 c=Hello<br>World

--- a/tests/fixtures/render_complex_architecture_diagram.dsl
+++ b/tests/fixtures/render_complex_architecture_diagram.dsl
@@ -1,7 +1,7 @@
 collision off
-box 4 2 31 3 id=bb s=r a=c c=Browser (Scenario B)\nConnect BO User
-box 56 2 36 3 id=ba s=r a=c c=Browser (Scenario A)\nConnect FO User
-box 114 2 38 3 id=bc s=r a=c c=Browser (Scenario C)\nConsole Admin
+box 4 2 31 3 id=bb s=r a=c c=Browser (Scenario B)<br>Connect BO User
+box 56 2 36 3 id=ba s=r a=c c=Browser (Scenario A)<br>Connect FO User
+box 114 2 38 3 id=bc s=r a=c c=Browser (Scenario C)<br>Console Admin
 text 22 7 c=B1. as-is: https://app-bo.example.com
 text 22 8 c=    to-be: https://app.example.com/backoffice
 text 22 10 c=A1. as-is: https://app-fo.example.com
@@ -15,9 +15,9 @@ box 4 22 31 1 id=boc s=r a=c c=BO Client (Port 3104)
 box 114 22 38 1 id=csc s=r a=c c=Console Client (MF Host, Port 5001)
 text 22 25 c=B2. as-is: GET https://api.example.com/connect/v1/back-office/users
 text 22 26 c=    to-be: GET https://app.example.com/api/backoffice/v1/users
-box 30 28 92 18 id=cs s=d lp=t lg=App Server (Port 8007) c=Endpoints:\n  FO:      /v1/users, /v1/orders, /v1/organizations\n  BO:      /v1/back-office/users, /v1/back-office/orders\n  Console: /api/v1/console/{users,orgs,roles}\n  MF:      /mf/**\n\nAuth:\n  @Order(1) /api/v*/console/**\n    -> ConsoleApiAuthFilter\n  @Order(2) /**\n    -> permitAll + RoleInterceptor
-box 70 40 48 3 id=ccc s=h a=c c=Console MF Client\n(MF Remote)\nServed as static /mf/**
-box 36 52 84 5 id=css s=d lp=t lg=Console Server (Port 8504) c=Auth:     /console/v1/sessions/verify -> session validation\nEmployee: /v1/employees/me (self only)\nEmployee: /v1/employees (CUD, admin menu)
+box 30 28 92 18 id=cs s=d lp=t lg=App Server (Port 8007) c=Endpoints:<br>  FO:      /v1/users, /v1/orders, /v1/organizations<br>  BO:      /v1/back-office/users, /v1/back-office/orders<br>  Console: /api/v1/console/{users,orgs,roles}<br>  MF:      /mf/**<br><br>Auth:<br>  @Order(1) /api/v*/console/**<br>    -> ConsoleApiAuthFilter<br>  @Order(2) /**<br>    -> permitAll + RoleInterceptor
+box 70 40 48 3 id=ccc s=h a=c c=Console MF Client<br>(MF Remote)<br>Served as static /mf/**
+box 36 52 84 5 id=css s=d lp=t lg=Console Server (Port 8504) c=Auth:     /console/v1/sessions/verify -> session validation<br>Employee: /v1/employees/me (self only)<br>Employee: /v1/employees (CUD, admin menu)
 arrow ba.b foc.t
 arrow foc.b cs.t
 arrow bb.b boc.t


### PR DESCRIPTION
## Summary
- content/legend의 멀티라인 구분자를 `\n`에서 `<br>`로 변경
- shell 파이핑(`echo "DSL" | unid`) 시 zsh 에러 해결
- 파서, 테스트, fixture, guide 일괄 업데이트

Closes #2

## Test plan
- [x] `mise run test` — 전체 테스트 통과
- [ ] `echo "collision off\nbox 0 0 10 3 c=Line1<br>Line2" | unid` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)