### PR TITLE
feat: add align attribute to text objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ integration_test.go  CLI 통합 테스트
 - `printGuide()` 예제 DSL 변경 시 OUTPUT 영역을 실제 `go run ./cmd/unid` 결과로 교체 (필수)
 - 예제의 다양성 유지: 모든 테두리 스타일, 다양한 arrow 형태, CJK 텍스트, overflow 데모 포함
 
+## DSL 옵션 규칙
+
+- 새 속성 추가 시 shorthand(약어) 필수 (예: `align` / `a`, `content` / `c`, `legend` / `lg`)
+
 ## 코드 변경 시 문서 업데이트
 
 - DSL 문법, 옵션, 커맨드 변경 시 `printGuide()` 업데이트 검토 (필수)

--- a/cmd/unid/guide.go
+++ b/cmd/unid/guide.go
@@ -31,7 +31,7 @@ DSL SYNTAX:
         [legend(lg)=<text>] [content(c)=<text>]
       - W, H: inner size (border excluded). Total: (W+2) x (H+2)
       - "rect" is accepted as an alias for "box"
-    text <col> <row> [id=<name>] content(c)=<text>
+    text <col> <row> [id=<name>] [align(a)=<align>] content(c)=<text>
     hline <col> <row> <length> [id=<name>] [style(s)=<style>] [pos=<pos>]
         [legend-overflow(lo)=<mode>] [legend-align(la)=<align>] [legend(lg)=<text>]
     vline <col> <row> <length> [id=<name>] [style(s)=<style>] [pos=<pos>]

--- a/cmd/unid/main.go
+++ b/cmd/unid/main.go
@@ -273,7 +273,7 @@ func runRender() error {
 	r.GlobalOverflow = config.globalOverflow
 	r.GlobalAlign = config.globalAlign
 
-	// Apply global defaults to rects
+	// Apply global defaults to rects and texts
 	objects := make([]object.DrawObject, len(config.objects))
 	for i, obj := range config.objects {
 		if rect, ok := obj.(*object.Rect); ok {
@@ -282,6 +282,11 @@ func runRender() error {
 			}
 			if rect.ContentAlign == object.AlignLeft {
 				rect.ContentAlign = config.globalAlign
+			}
+		}
+		if text, ok := obj.(*object.Text); ok {
+			if text.ContentAlign == object.AlignLeft {
+				text.ContentAlign = config.globalAlign
 			}
 		}
 		objects[i] = obj

--- a/internal/dsl/parser.go
+++ b/internal/dsl/parser.go
@@ -228,12 +228,19 @@ func parseText(tokens []string, line int) (DslCommand, error) {
 	greedyIdx := greedyTokenIndex(tokens, 3)
 	var id string
 
+	var align object.ContentAlign
 	for _, token := range tokens[3:greedyIdx] {
 		if v, ok := stripOption(token, "id"); ok {
 			if err := validateID(v, line); err != nil {
 				return nil, err
 			}
 			id = v
+		} else if v, ok := stripOption(token, "align", "a"); ok {
+			ca, err := parseContentAlign(v, line)
+			if err != nil {
+				return nil, err
+			}
+			align = ca
 		} else {
 			return nil, &uerr.ParseError{Line: line, Message: fmt.Sprintf("unknown text option '%s'", token)}
 		}
@@ -245,6 +252,7 @@ func parseText(tokens []string, line int) (DslCommand, error) {
 	}
 	text := object.NewText(col, row, content)
 	text.ID = id
+	text.ContentAlign = align
 	return &ObjectCmd{Object: text}, nil
 }
 

--- a/internal/object/text.go
+++ b/internal/object/text.go
@@ -7,16 +7,17 @@ import (
 )
 
 type Text struct {
-	Col, Row int
-	Content  string
-	ID       string
+	Col, Row     int
+	Content      string
+	ID           string
+	ContentAlign ContentAlign
 }
 
 func NewText(col, row int, content string) *Text {
 	return &Text{Col: col, Row: row, Content: content}
 }
 
-func (t *Text) bboxWidth() int {
+func (t *Text) BBoxWidth() int {
 	maxW := 0
 	for _, line := range strings.Split(t.Content, "\n") {
 		if w := width.StrWidth(line); w > maxW {
@@ -35,7 +36,7 @@ func (t *Text) bboxHeight() int {
 }
 
 func (t *Text) SrcAnchor(side Side) (int, int) {
-	w := t.bboxWidth()
+	w := t.BBoxWidth()
 	h := t.bboxHeight()
 	switch side {
 	case SideTop:

--- a/internal/renderer/engine.go
+++ b/internal/renderer/engine.go
@@ -311,8 +311,17 @@ func (r *Renderer) drawLegendText(col, row int, legend *object.Legend, idx int) 
 // --- Text ---
 
 func (r *Renderer) drawText(text *object.Text, idx int) error {
+	maxW := text.BBoxWidth()
 	for i, line := range strings.Split(text.Content, "\n") {
-		if err := r.Canvas.PutStr(text.Col, text.Row+i, line, r.Collision, idx); err != nil {
+		padLeft := 0
+		lineW := width.StrWidth(line)
+		switch text.ContentAlign {
+		case object.AlignCenter:
+			padLeft = max(maxW-lineW, 0) / 2
+		case object.AlignRight:
+			padLeft = max(maxW-lineW, 0)
+		}
+		if err := r.Canvas.PutStr(text.Col+padLeft, text.Row+i, line, r.Collision, idx); err != nil {
 			return err
 		}
 	}

--- a/tests/fixtures/text_align_center.dsl
+++ b/tests/fixtures/text_align_center.dsl
@@ -1,0 +1,2 @@
+collision off
+text 0 0 a=c c=Hi\nWorld!

--- a/tests/fixtures/text_align_center.golden
+++ b/tests/fixtures/text_align_center.golden
@@ -1,0 +1,2 @@
+  Hi
+World!

--- a/tests/fixtures/text_align_right.dsl
+++ b/tests/fixtures/text_align_right.dsl
@@ -1,0 +1,2 @@
+collision off
+text 0 0 a=r c=Hi\nWorld!

--- a/tests/fixtures/text_align_right.golden
+++ b/tests/fixtures/text_align_right.golden
@@ -1,0 +1,2 @@
+    Hi
+World!


### PR DESCRIPTION
## Summary
- text 객체에 `align(a)=` 옵션 추가 (left/center/right)
- 멀티라인 text에서 bboxWidth 기준 정렬
- global `align` 커맨드도 text 객체에 적용
- CLAUDE.md에 shorthand 필수 지침 추가

Closes #3

## Test plan
- [x] `mise run test` — 전체 테스트 통과
- [x] text_align_center, text_align_right golden 테스트 추가
- [ ] `echo "collision off\ntext 0 0 a=c c=Hi\nWorld!" | unid` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)